### PR TITLE
Add Directive params

### DIFF
--- a/app/BaseDirective.php
+++ b/app/BaseDirective.php
@@ -29,6 +29,7 @@ abstract class BaseDirective extends BaseHandler
 		'subreddits' => [], // Array of strings, the portion after "/r/"
 		'patterns'   => [], // Regex patterns to match
 		'actions'    => [], // Actions to use during execution
+		'params'     => [], // Arrays of parameters to pass to each Action
 	];
 
 	/**

--- a/app/Commands/RedditExecute.php
+++ b/app/Commands/RedditExecute.php
@@ -31,9 +31,9 @@ class RedditExecute extends RedditCommand
 				throw new RuntimeException('Unknown Directive: ' . $submission->directive);
 			}
 
-			foreach ($this->directives[$submission->directive]->actions as $class)
+			foreach ($this->directives[$submission->directive]->actions as $i => $class)
 			{
-				(new $class)->execute($submission);
+				(new $class)->execute($submission, $directive->params[$i] ?? []);
 			}
 
 			// Mark them as executed as we go in case tasks are run in parallel

--- a/tests/_support/Directives/TestDirective.php
+++ b/tests/_support/Directives/TestDirective.php
@@ -22,5 +22,6 @@ class TestDirective extends BaseDirective
 			'/Hots.?Logs/i',
 		],
 		'actions'    => [SessionAction::class], // Actions to use during execution
+		'params'     => [], // Arrays of parameters to pass to each Action
 	];
 }


### PR DESCRIPTION
Adds a `$params` attribute to Directives which will be used for `BaseAction::execute()`